### PR TITLE
Add ethernet documentation and scripts

### DIFF
--- a/ethernet/README.md
+++ b/ethernet/README.md
@@ -1,0 +1,41 @@
+# Ethernet port on Xiaomi Gateway v3
+
+## Ethernet DIY
+| Xiaomi Gateway v3 | HR911105a Ethernet |
+|:---:|:-----:|
+| TX+ | Pin 1 |
+| TX- | Pin 2 |
+| RX+ | Pin 3 |
+| RX- | Pin 6 |
+| GND | Pin 8 |
+
+![Ethernet pinout](../media/mgl03_back_uart_eth.jpg)
+
+## Ethernet Configuration
+
+The Xiaomi Gateway v3 firmware constantly monitors wifi status by running `/bin/daemon_app.sh`.
+This script checks if wifi is running, and if it's not running it will restart all the wifi configuration from scratch, which will cause ethernet-wifi bridging issues, flooding your network with packets.
+The only way to prevent the firmware from restarting wifi is by launching two never-ending scripts that will prevent the wifi from being restarted.
+This works because `/bin/daemon_app.sh` and `/bin/wifi_check.sh` check if these scripts are already running before starting them:
+```
+if [ "`ps -ww | grep wifi_check.sh | grep -v grep`xx" == "xx" ]
+then
+    wifi_check.sh
+fi
+```
+```
+if [ "`ps -w | grep wifi_start.sh | grep -v grep`xx" == "xx" ]
+then
+    wifi_start.sh
+fi
+```
+
+### Firmware 1.4.7_0065
+
+1. Copy `wifi_check.sh` and `wifi_start.sh` to `/data`.
+2. Add `/data/wifi_check.sh &` to `run.sh`:
+```
+#!/bin/sh
+/data/wifi_check.sh &
+```
+3. Reboot your gateway (wlan0 should be disabled and eth0 should be enabled).

--- a/ethernet/wifi_check.sh
+++ b/ethernet/wifi_check.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+loop=true
+while $loop; do
+	if [ "$(cat /sys/class/net/wlan0/operstate)" == "up" ]; then
+		echo -e "wlan0 is up!"
+		loop=false
+	else
+		echo -e "wlan0 is down!"
+	fi
+
+	sleep 5
+done
+
+/data/wifi_start.sh &
+
+ifconfig wlan0 down
+touch /tmp/dont_need_monitor_wpa_supplicant
+killall wpa_supplicant
+ifconfig eth0 up
+
+while true; do
+	# Keep script alive to prevent wifi respawn
+	sleep 300
+done

--- a/ethernet/wifi_start.sh
+++ b/ethernet/wifi_start.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+while true; do
+	# Keep script alive to prevent wifi respawn
+	sleep 300
+done


### PR DESCRIPTION
Ethernet needs a couple of scripts on firmware 1.4.7_0065 to automatically
start on boot and properly disable wifi.

Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>