### PR TITLE
Add additional warning regarding UART connection pinout

### DIFF
--- a/uart_recovery/README.md
+++ b/uart_recovery/README.md
@@ -13,6 +13,8 @@
    UART Tx  <--> TP4 (Gateway Rx)  
    UART Rx  <--> TP11 (Gateway Tx)  
    UART GND <--> TP8  (Gateway GND)
+   
+   WARNING: be careful to connect **Tx with Rx**, not Tx-Tx and Rx-Rx
 
    <img src="https://user-images.githubusercontent.com/511909/98268507-a8f6b880-1f9d-11eb-80f6-3ae2bee27c5e.png" width="640">
    


### PR DESCRIPTION
I just made a mistake by not checking the connection again after I made it Tx-Tx and Rx-Rx. I was following the forum posts that don't state it clearly. It appears that a similar problem may be related to the issue #18.